### PR TITLE
Reverting to Thread.Sleep() and Wtcp.IsConnected()

### DIFF
--- a/WatsonCluster/ClusterClient.cs
+++ b/WatsonCluster/ClusterClient.cs
@@ -59,7 +59,7 @@ namespace WatsonCluster
                 if (Debug) Console.WriteLine("Client object is null");
                 return false;
             }
-            return Wtcp.Connected;
+            return Wtcp.IsConnected();
         }
 
         public bool Send(byte[] data)
@@ -70,7 +70,7 @@ namespace WatsonCluster
                 return false;
             }
 
-            if (Wtcp.Connected)
+            if (Wtcp.IsConnected())
             {
                 Wtcp.Send(data);
                 return true;
@@ -92,22 +92,18 @@ namespace WatsonCluster
             {
                 try
                 {
-                    Task.Delay(1000).Wait();
-
                     if (Wtcp == null)
                     {
                         if (Debug) Console.WriteLine("Attempting connection to " + ServerIp + ":" + ServerPort);
                         Wtcp = new WatsonTcpClient(ServerIp, ServerPort, ServerConnected, ServerDisconnected, MsgReceived, Debug);
-                        continue;
                     }
-
-                    if (!Wtcp.Connected)
+                    else if (!Wtcp.IsConnected())
                     {
                         if (Debug) Console.WriteLine("Attempting reconnect to " + ServerIp + ":" + ServerPort);
                         Wtcp.Dispose();
                         Wtcp = new WatsonTcpClient(ServerIp, ServerPort, ServerConnected, ServerDisconnected, MsgReceived, Debug);
-                        continue;
                     }
+                    Thread.Sleep(1000);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Other than reverting previous changes, the order of execution is changed
so that it no longer sleeps before the initial connection attempt.
Recommending to defer implementing non-blocking support for now, and
continue using short-interrupt. Changing back to IsConnected() from
Connected for compatibility with the prior version of WatsonTcp.