### PR TITLE
Update to use async methods in WatsonTcp

### DIFF
--- a/WatsonCluster/ClusterClient.cs
+++ b/WatsonCluster/ClusterClient.cs
@@ -82,6 +82,26 @@ namespace WatsonCluster
             }
         }
 
+        public async Task<bool> SendAsync(byte[] data)
+        {
+            if (Wtcp == null)
+            {
+                if (Debug) Console.WriteLine("Client is null, cannot send");
+                return false;
+            }
+
+            if (Wtcp.IsConnected())
+            {
+                await Wtcp.SendAsync(data);
+                return true;
+            }
+            else
+            {
+                if (Debug) Console.WriteLine("Client is not connected, cannot send");
+                return false;
+            }
+        }
+
         public void Dispose()
         {
             Dispose(true);

--- a/WatsonCluster/ClusterNode.cs
+++ b/WatsonCluster/ClusterNode.cs
@@ -124,6 +124,33 @@ namespace WatsonCluster
             return false;
         }
 
+
+        public async Task<bool> SendAsync(byte[] data)
+        {
+            if (Client != null)
+            {
+                if (Client.IsConnected())
+                {
+                    return await Client.SendAsync(data);
+                }
+            }
+            else if (String.IsNullOrEmpty(CurrPeerIpPort))
+            {
+                if (Debug) Console.WriteLine("No peer connected");
+                return false;
+            }
+            else if (Server != null)
+            {
+                if (Server.IsConnected(CurrPeerIpPort))
+                {
+                    return await Server.SendAsync(CurrPeerIpPort, data);
+                }
+            }
+
+            if (Debug) Console.WriteLine("Neither server or client are healthy");
+            return false;
+        }
+
         public void Dispose()
         {
             Dispose(true);

--- a/WatsonCluster/ClusterServer.cs
+++ b/WatsonCluster/ClusterServer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using WatsonTcp;
 
@@ -68,6 +69,25 @@ namespace WatsonCluster
             if (Wtcp.IsClientConnected(ipPort))
             {
                 Wtcp.Send(ipPort, data);
+                return true;
+            }
+            else
+            {
+                if (Debug) Console.WriteLine("Server is not connected, cannot send");
+                return false;
+            }
+        }
+
+        public async Task<bool> SendAsync(string ipPort, byte[] data)
+        {
+            if (Wtcp == null)
+            {
+                if (Debug) Console.WriteLine("Server is null, cannot send");
+                return false;
+            }
+            if (Wtcp.IsClientConnected(ipPort))
+            {
+                await Wtcp.SendAsync(ipPort, data);
                 return true;
             }
             else

--- a/WatsonCluster/WatsonCluster.csproj
+++ b/WatsonCluster/WatsonCluster.csproj
@@ -40,9 +40,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="WatsonTcp, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\WatsonTcp.1.0.5\lib\WatsonTcp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="WatsonTcp, Version=1.0.6.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\WatsonTcp\WatsonTcp\bin\Debug\WatsonTcp.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This goes with the recent changes on the async-to-the-core branch of WatsonTcp.